### PR TITLE
Add basic solaris support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,10 +14,12 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.require_version ">= 1.5.0"
 
+GO_VERSION = "1.8rc3"
+
 # See http://dl.golang.org/dl/
 GO_ARCHIVES = {
-  "linux" => "go1.8rc3.linux-amd64.tar.gz",
-  "bsd" => "go1.8rc3.freebsd-amd64.tar.gz",
+  "linux" => "go#{GO_VERSION}.linux-amd64.tar.gz",
+  "bsd" => "go#{GO_VERSION}.freebsd-amd64.tar.gz",
   "solaris" => ""
 }
 


### PR DESCRIPTION
This uses the openindiana/hipster vagrant image. This looked the most
official (not sure whether those solaris* images are good license-wise).

This required some modifications though:

* There is no prebuilt Go binary for solaris (using that from package
  manager, which is 1.6 as of now).
* For cgo to work a compiler is needed. I'm not that much of a solaris
  expert to exactly know what is needed. Therefore I added the
  build-essential package, but that downloads half the internet.
* The vagrant user's home directory is `/export/home/vagrant`.

Some future addition I'd like to make is building Go from source, which is possible with build-essential being installed anyway. But for a first version this should be sufficient.

Tested that at least the linux version still works (bsd failed due to problems with nfs).